### PR TITLE
chore(pre-commit): change repo to use local linter binaries

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,18 @@
 ---
 repos:
-  - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.29.0
+  - repo: local
     hooks:
       - id: yamllint
-        args: ["-c=.yamllint.yml", "."]
-  - repo: https://github.com/ansible-community/ansible-lint.git
-    rev: v6.11.0
-    hooks:
+        name: yamllint
+        entry: |
+          yamllint -c=.yamllint.yml .
+        language: system
+        types: [yaml]
+        pass_filenames: false
       - id: ansible-lint
-        args: ["-c", ".ansible-lint"]
-        files: \.(yaml|yml)$
+        name: ansible-lint
+        entry: |
+          ansible-lint -c .ansible-lint
+        language: system
+        types: [yaml]
+        pass_filenames: false


### PR DESCRIPTION
Because otherwise I would have to maintain/keep track of different
versions of the binaries in pre-commit itself and those used by gh
actions/molecule